### PR TITLE
Have a full populated default config with indentation

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -57,7 +57,13 @@ exports.handler = async args => {
   try {
     fs.statSync(configPath);
   } catch (e) {
-    const defaultConfig = JSON.stringify({name: folderName});
+    const defaultConfig = JSON.stringify({
+        name: folderName,
+        restart: "on-failure:2",
+        domain:null,
+        env:{},
+        hostname:null
+    },null,2) + "\n";
     fs.writeFileSync(configPath, defaultConfig, 'utf-8');
   }
 


### PR DESCRIPTION
This PR changes the configuration that is written to the project dir when exoframe is called with no configuration in place from:
`{"name":"$name"}`
to
```
{
  "name": "$name",
  "restart": "on-failure:2",
  "domain": null,
  "env": {},
  "hostname": null
}
```

the values represent (or have the same impact) as the default values.
It helps to configure the project without consulting the documentation.