### PR TITLE
Fail early if the configuration is invalid JSON 

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -64,12 +64,12 @@ exports.handler = async args => {
   // show loader
   const spinner = ora('Uploading project to server...').start();
 
-  //syntax-check config
+  // syntax-check config
   try {
     JSON.parse(fs.readFileSync(configPath));
-  } catch (e){
-      spinner.fail("Your exoframe.json is not valid");
-      return;
+  } catch (e) {
+    spinner.fail('Your exoframe.json is not valid');
+    return;
   }
 
   // create tar stream from current folder

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -69,6 +69,7 @@ exports.handler = async args => {
     JSON.parse(fs.readFileSync(configPath));
   } catch (e) {
     spinner.fail('Your exoframe.json is not valid');
+    console.log(chalk.red('Please, check your config and try again.'));
     return;
   }
 

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -61,6 +61,17 @@ exports.handler = async args => {
     fs.writeFileSync(configPath, defaultConfig, 'utf-8');
   }
 
+  // show loader
+  const spinner = ora('Uploading project to server...').start();
+
+  //syntax-check config
+  try {
+    JSON.parse(fs.readFileSync(configPath));
+  } catch (e){
+      spinner.fail("Your exoframe.json is not valid");
+      return;
+  }
+
   // create tar stream from current folder
   const ig = ignore().add(ignores);
   const tarStream = tar.pack(workdir, {
@@ -72,9 +83,6 @@ exports.handler = async args => {
       Authorization: `Bearer ${userConfig.token}`,
     },
   };
-
-  // show loader
-  const spinner = ora('Uploading project to server...').start();
 
   // pipe stream to remote
   try {


### PR DESCRIPTION
This addresses #38 
I try to parse the configuration as early as possible to stop the deployment on a broken configuration.

I'm not sure about the error-reporting-method.
Let me know if we should report in a different way.