### PR TITLE
Add config alias

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -7,7 +7,7 @@ const inquirer = require('inquirer');
 const validate = input => input && input.length > 0;
 const filter = input => (input ? input.trim() : '');
 
-exports.command = 'config';
+exports.command = ['config', 'init'];
 exports.describe = 'generate new config file for current project';
 exports.builder = {};
 exports.handler = async () => {


### PR DESCRIPTION
Minor nitpick, but I think it could be helpful having `exoframe init` be an alias of `exoframe config`. Init is more common for generating an initial config json, e.g. `npm init`, `bower init`.