### PR TITLE
Add docs for frontend basic auth

### DIFF
--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -100,7 +100,7 @@ Config file has the following structure:
   },
   // rate-limit config
   // see "advanced topics" for more info
-  "rate-limit": {
+  "rateLimit": {
     // rate-limit time period
     "period": "1s",
     // request rate over given time period

--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -110,7 +110,11 @@ Config file has the following structure:
   },
   // template to be used for project deployment
   // undefined by default, detected by server based on file structure
-  "template": "my-template"
+  "template": "my-template",
+  // basic auth, [optional]
+  // this field allows you to have basic auth to access your deployed service
+  // format is in user:pwhash
+  "basicAuth": "user:$apr1$$9Cv/OMGj$$ZomWQzuQbL.3TRCS81A1g/"
 }
 ```
 


### PR DESCRIPTION
Should now close #168 

I also fixed typo in docs. Rate limit field was set as `rate-limit` but should be `rateLimit` in the config section.