### PR TITLE
Fixes #188 - Add Documentation for private key format requirements

### DIFF
--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -139,6 +139,10 @@ Currently it contains list of endpoint URLs with associated usernames and authen
 endpoint: 'http://localhost:8080' # your endpoint URL, defaults to localhost
 ```
 
+## SSH key auth
+
+The SSK key needs to be RSA and in PEM format. To ensure your key is generated in a format that works you can generate with this command: `ssh-keygen -t rsa -b 4096 -C "your_email@example.com" -m 'PEM'`. This follows the [GitHub Instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/) with an additional flag ensuring it is the right format.
+
 ## Deployment tokens
 
 Sometimes you might need to deploy things from environments that don't have your private key (e.g. CI/CD services).  


### PR DESCRIPTION
I debated whether to put something on the main README, but I don't know how common this will be. So, I added it to the Basic documentation.

I also, just to be sure, followed the github instructions for creating an RSA key. It wouldn't work with my MBP. I had to add the PEM flag. 

Let me know if you want it worded differently or anything.