### PR TITLE
Update ServerConfiguration.md

### DIFF
--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -52,6 +52,8 @@ plugins:
   # specific plugin config (see plugins docs to know what property they use)
   swarm:
     enabled: true
+    # Your custom swarm network, defaults to exoframe-swarm
+    network: exoframe-swarm
 ```
 
 _Warning:_ Most changes to config are applied immediately. With exception of Letsencrypt config and Plugins config.  


### PR DESCRIPTION
Added network to plugin config.  While it does _create_ the default exoframe-swarm network, it does not appear to properly use it, so if this value is not defined the docker container hangs with unresolved promise errors after a 400 error related to the network