### PR TITLE
Added traefikPath option to server configuration

### DIFF
--- a/docs/ServerConfiguration.md
+++ b/docs/ServerConfiguration.md
@@ -30,6 +30,10 @@ traefikImage: 'traefik:latest'
 # Traefik container name, default "exoframe-traefik"
 traefikName: 'exoframe-traefik'
 
+# Traefik storage volume binding, where traefik acme certificates are stored
+# default `${os.homedir()}/.exoframe/traefik`
+traefikPath: '/path/to/your/traefik/storage/folder'
+
 # Additional Traefik start args, default []
 traefikArgs: []
 


### PR DESCRIPTION
Adds traefikPath option to server config for traefik container volume mount point.

This fixes my issue:
[https://github.com/exoframejs/exoframe/issues/268](https://github.com/exoframejs/exoframe/issues/268)