### PR TITLE
Update deploy.js

### DIFF
--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -183,7 +183,7 @@ exports.handler = async (args = {}) => {
   const tarStream = tar.pack(workdir, {
     // ignore files from ignore list
     ignore: name => {
-      const relativePath = name.replace(`${workdir}/`, '');
+      const relativePath = path.relative(workdir, name)
       const result = multimatch([relativePath], ignores).length !== 0;
       return result;
     },

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -183,7 +183,7 @@ exports.handler = async (args = {}) => {
   const tarStream = tar.pack(workdir, {
     // ignore files from ignore list
     ignore: name => {
-      const relativePath = path.relative(workdir, name)
+      const relativePath = path.relative(workdir, name);
       const result = multimatch([relativePath], ignores).length !== 0;
       return result;
     },


### PR DESCRIPTION
Executing on a Windows System the ignore logic fails, since the path string differs from a system we can give the task to Node and use path.relative 👍

https://nodejs.org/api/path.html#path_path_relative_from_to