### PR TITLE
Fix hyperlink for docker compose

### DIFF
--- a/docs/Basics.md
+++ b/docs/Basics.md
@@ -72,7 +72,7 @@ By default, Exoframe understands and can deploy the following project types:
 1.  Static html based projects - will be deployed using [nginx](http://hub.docker.com/_/nginx) image
 2.  Node.js based projects - will be deployed using [node:latest](https://hub.docker.com/_/node) image \*
 3.  Docker based project - will be deployed using your [Dockerfile](https://docs.docker.com/engine/reference/builder/)
-4.  [Docker-Compose based projects](docs/Advanced.md#Docker-Compose based deployment) - will be deployed using your [docker-compose](https://docs.docker.com/compose/compose-file/) file
+4.  [Docker-Compose based projects](./Advanced.md#Docker-Compose-based-deployment) - will be deployed using your [docker-compose](https://docs.docker.com/compose/compose-file/) file
 
 \* There are two things to keep in mind for Node.js projects: (1) they are started via `npm start`, so make sure you have specified start script in your `package.json`; (2) by default port 80 is exposed, so you need to make your app listen on that port. If you'd like to execute your app in any different way or expose more ports - please use Dockerfile deployment method.
 


### PR DESCRIPTION
change  docs/Advanced.md#Docker-Compose based deployment ->  ./Advanced.md#Docker-Compose-based-deployment

- spaces removed
- switch relative link