### PR TITLE
Fix/line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.ai binary


### PR DESCRIPTION
I was working on windows with `git config --global core.autocrlf true`
And almost all js files was with CRLF line endings. In that case also the tests was failing. By adding this file git is forced to use LF